### PR TITLE
Handle VerifyError when loading classes to keep REPL alive

### DIFF
--- a/src/io/github/protasm/lpcconsole/LPCConsole.java
+++ b/src/io/github/protasm/lpcconsole/LPCConsole.java
@@ -153,22 +153,22 @@ public class LPCConsole {
 			}
 		}.defineClass(sf.bytes());
 
-		// Instantiate the class using reflection
-		try {
-			// Assume a no-arg constructor
-			Constructor<?> constructor = clazz.getConstructor();
-			Object instance = constructor.newInstance();
+                // Instantiate the class using reflection
+                try {
+                        // Assume a no-arg constructor
+                        Constructor<?> constructor = clazz.getConstructor();
+                        Object instance = constructor.newInstance();
 
-			sf.setLPCObject(instance);
+                        sf.setLPCObject(instance);
 
-			return sf;
-		} catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException
-				| InstantiationException e) {
-			System.out.println(e.toString());
+                        return sf;
+                } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException
+                                | InstantiationException | VerifyError e) {
+                        System.out.println(e.toString());
 
-			return null;
-		}
-	}
+                        return null;
+                }
+        }
 
        public Object call(String className, String methodName, Object[] callArgs) {
                Object obj = objects.get(className);


### PR DESCRIPTION
## Summary
- Catch `VerifyError` during dynamic class instantiation so REPL continues after invalid bytecode

## Testing
- `javac @sources.txt` *(fails: package io.github.protasm.lpc2j.efun does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fef4d264832798644e1d91c81025